### PR TITLE
Application: add button to show password

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -25,6 +25,10 @@
       "ready": "Copy Password",
       "complete": "Copied"
     },
+    "show": {
+      "hidden": "Show Password",
+      "shown": "Hide Password"
+    },
     "compute": {
       "idle": "Compute Password",
       "running": "Computing Password"

--- a/src/pages/application.vue
+++ b/src/pages/application.vue
@@ -689,8 +689,8 @@ export default {
 
     hasPreset() {
       const preset = this.getPreset(this.app.domain);
-      if (preset.domain && preset.domain !== this.app.domain) {
-        return true;
+      if (!preset.domain || preset.domain !== this.app.domain) {
+        return false;
       }
 
       const options = preset.options;

--- a/src/pages/application.vue
+++ b/src/pages/application.vue
@@ -264,11 +264,18 @@
 
     <div class="d-flex flex-column flex-md-row application-buttons">
       <b-button
-        v-if="password"
+        v-if="password && !shown"
         variant="primary"
         @click="copyPassword">
         {{ copied ? $root.$t('button.copy.complete') :
            $root.$t('button.copy.ready') }}
+      </b-button>
+      <b-button
+        v-if="password"
+        :variant="shown ? 'primary' : 'outline-danger'"
+        @click="showPassword">
+        {{ shown ? $root.$t('button.show.shown') :
+           $root.$t('button.show.hidden') }}
       </b-button>
       <b-button
         v-else
@@ -286,6 +293,12 @@
         {{ $root.$t('button.back') }}
       </b-button>
     </div>
+
+    <h3
+      v-if="shown"
+      class="mb-2" >
+      {{ this.password }}
+    </h3>
 
     <computing
       :active="!!computing"
@@ -539,6 +552,7 @@ export default {
 
       showDetails: isNew,
       copied: false,
+      shown: false,
       saved: false,
       computing: false,
       error: null,
@@ -772,6 +786,7 @@ export default {
       // Reset password
       this.password = '';
       this.copied = false;
+      this.shown = false;
       this.saved = false;
 
       if (this.presetDomain && this.app.domain !== this.presetDomain) {
@@ -787,6 +802,10 @@ export default {
       setTimeout(() => this.copied = false, 2500);
 
       this.$copyText(this.password);
+    },
+    showPassword() {
+      this.shown = !this.shown;
+      setTimeout(() => this.shown = false, 20000);
     },
     onSave() {
       const app = Object.assign(this.app, { changedAt: Date.now() });


### PR DESCRIPTION
This is very useful for manually entering passwords into devices that are unable to access derivepass.

Also fixes a silly warning display bug.

<img width="449" alt="Screen Shot 2020-01-06 at 6 03 27 PM" src="https://user-images.githubusercontent.com/1093990/71855414-f620aa00-30ae-11ea-97eb-10788b12ca55.png">
<img width="422" alt="Screen Shot 2020-01-06 at 6 03 33 PM" src="https://user-images.githubusercontent.com/1093990/71855424-f91b9a80-30ae-11ea-8563-fbd47f3cfdf2.png">

I suppose I could add more space between the buttons... I'm not sure how best to do so without making something custom though. Something about margins and negation via `:first-child` and `:last-child`...